### PR TITLE
Fix issue preventing using vue tags input in an vue3 project

### DIFF
--- a/vue-tags-input/publish.js
+++ b/vue-tags-input/publish.js
@@ -4,7 +4,7 @@ import TagInput from '../vue-tags-input/tag-input.vue';
 
 // add autoinstall support if the component is attached to the windows object e.g. if added by CDN
 VueTagsInput.install = Vue => Vue.component(VueTagsInput.name, VueTagsInput);
-if (typeof window !== 'undefined' && window.Vue) window.Vue.use(VueTagsInput);
+if (typeof window !== 'undefined' && window.Vue && window.Vue.use) window.Vue.use(VueTagsInput);
 
 export {
   VueTagsInput,


### PR DESCRIPTION
Hi, in vue 3 there is no `Vue.use()` it is done via:

```js
import { createApp } from 'vue'

const app = createApp({})

app.use(myPlugin)
```

So this just makes sure there is a .use() available before trying to call it... 
